### PR TITLE
Add colonist job priority UI

### DIFF
--- a/Assets/Scripts/Colonists/Colonist.cs
+++ b/Assets/Scripts/Colonists/Colonist.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -16,6 +17,8 @@ public class Colonist : MonoBehaviour
     [Range(0f,1f)] public float fatigue;
     [Range(0f,1f)] public float stress;
     [Range(0f,1f)] public float social;
+
+    public HashSet<JobType> jobPriorities = new HashSet<JobType>();
 
     private Task currentTask;
     private TaskManager taskManager;
@@ -50,6 +53,9 @@ public class Colonist : MonoBehaviour
         map = FindObjectOfType<MapGenerator>();
         taskManager = FindObjectOfType<TaskManager>();
 
+        foreach (JobType jt in System.Enum.GetValues(typeof(JobType)))
+            jobPriorities.Add(jt);
+
         // initialize stats with random values so the info card has data
         hunger = Random.Range(0f, 1f);
         fatigue = Random.Range(0f, 1f);
@@ -64,6 +70,16 @@ public class Colonist : MonoBehaviour
         if (taskManager == null)
             taskManager = FindObjectOfType<TaskManager>();
     }
+
+    public void SetJobAllowed(JobType job, bool allowed)
+    {
+        if (allowed)
+            jobPriorities.Add(job);
+        else
+            jobPriorities.Remove(job);
+    }
+
+    public bool IsJobAllowed(JobType job) => jobPriorities.Contains(job);
 
     public void SetTask(Task task)
     {

--- a/Assets/Scripts/Colonists/JobType.cs
+++ b/Assets/Scripts/Colonists/JobType.cs
@@ -1,0 +1,8 @@
+public enum JobType
+{
+    Build,
+    Chop,
+    Haul,
+    Farm,
+    Doctor
+}

--- a/Assets/Scripts/UI/ColonistMenuController.cs
+++ b/Assets/Scripts/UI/ColonistMenuController.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using UnityEngine;
 using UnityEngine.UI;
+using System;
 
 public class ColonistMenuController : MonoBehaviour
 {
@@ -59,22 +60,75 @@ public class ColonistMenuController : MonoBehaviour
     {
         foreach (Transform t in menuPanel.transform)
             GameObject.Destroy(t.gameObject);
+        JobType[] jobs = (JobType[])Enum.GetValues(typeof(JobType));
+
+        GameObject header = new GameObject("Header");
+        header.transform.SetParent(menuPanel.transform, false);
+        HorizontalLayoutGroup hLayout = header.AddComponent<HorizontalLayoutGroup>();
+        hLayout.spacing = 5f;
+
+        CreateHeaderCell(header, "Colonist");
+        foreach (var j in jobs)
+            CreateHeaderCell(header, j.ToString());
 
         Colonist[] cols = GameObject.FindObjectsOfType<Colonist>();
         foreach (var c in cols)
         {
-            GameObject tObj = new GameObject(c.name);
-            tObj.transform.SetParent(menuPanel.transform, false);
-            Text t = tObj.AddComponent<Text>();
-            t.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
-            t.color = Color.black;
-            t.alignment = TextAnchor.MiddleLeft;
-            int mood = Mathf.RoundToInt(c.mood * 100f);
-            int health = Mathf.RoundToInt(c.health * 100f);
-            t.text = $"{c.name} - \u0437\u0434\u043e\u0440\u043e\u0432\u044c\u0435 {health}% \u043d\u0430\u0441\u0442\u0440\u043e\u0435\u043d\u0438\u0435 {mood}%";
-            RectTransform tr = t.GetComponent<RectTransform>();
-            tr.sizeDelta = new Vector2(0f, 20f);
+            GameObject row = new GameObject(c.name + "Row");
+            row.transform.SetParent(menuPanel.transform, false);
+            HorizontalLayoutGroup layout = row.AddComponent<HorizontalLayoutGroup>();
+            layout.spacing = 5f;
+
+            CreateRowLabel(row, c.name);
+
+            foreach (var j in jobs)
+            {
+                Toggle t = CreateRowToggle(row, c.IsJobAllowed(j));
+                JobType jt = j; Colonist col = c;
+                t.onValueChanged.AddListener(val => col.SetJobAllowed(jt, val));
+            }
         }
+    }
+
+    void CreateHeaderCell(GameObject parent, string text)
+    {
+        GameObject tObj = new GameObject(text);
+        tObj.transform.SetParent(parent.transform, false);
+        Text t = tObj.AddComponent<Text>();
+        t.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+        t.color = Color.black;
+        t.alignment = TextAnchor.MiddleCenter;
+        t.text = text;
+        RectTransform tr = t.GetComponent<RectTransform>();
+        tr.sizeDelta = new Vector2(0f, 20f);
+    }
+
+    void CreateRowLabel(GameObject parent, string text)
+    {
+        GameObject tObj = new GameObject("Label");
+        tObj.transform.SetParent(parent.transform, false);
+        Text t = tObj.AddComponent<Text>();
+        t.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+        t.color = Color.black;
+        t.alignment = TextAnchor.MiddleLeft;
+        t.text = text;
+        RectTransform tr = t.GetComponent<RectTransform>();
+        tr.sizeDelta = new Vector2(80f, 20f);
+    }
+
+    Toggle CreateRowToggle(GameObject parent, bool state)
+    {
+        GameObject obj = new GameObject("Toggle");
+        obj.transform.SetParent(parent.transform, false);
+        Toggle tog = obj.AddComponent<Toggle>();
+        Image bg = obj.AddComponent<Image>();
+        bg.color = state ? new Color(0.5f,1f,0.5f,1f) : Color.white;
+        tog.targetGraphic = bg;
+        tog.onValueChanged.AddListener(v => bg.color = v ? new Color(0.5f,1f,0.5f,1f) : Color.white);
+        tog.isOn = state;
+        RectTransform rt = obj.GetComponent<RectTransform>();
+        rt.sizeDelta = new Vector2(20f, 20f);
+        return tog;
     }
 
     public void AssignToggleButton(Image img)


### PR DESCRIPTION
## Summary
- define a `JobType` enum listing common jobs
- store selected jobs per colonist and expose helpers
- extend Colonist menu UI to show a table with toggles for job types

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68501ee41e6c832ab20ff481ae7c5b59