### PR TITLE
Respect colonist job settings when assigning tasks

### DIFF
--- a/Assets/Scripts/Colonists/BuildWallTask.cs
+++ b/Assets/Scripts/Colonists/BuildWallTask.cs
@@ -14,7 +14,7 @@ public class BuildWallTask : Task
     public WoodLog targetLog;
 
     public BuildWallTask(Vector2Int cell, float buildTime, int woodNeeded,
-        System.Action<Colonist> onComplete = null) : base(Vector2.zero, onComplete)
+        System.Action<Colonist> onComplete = null) : base(Vector2.zero, onComplete, JobType.Build)
     {
         this.cell = cell;
         this.buildTime = buildTime;

--- a/Assets/Scripts/Colonists/ChopTreeTask.cs
+++ b/Assets/Scripts/Colonists/ChopTreeTask.cs
@@ -2,7 +2,8 @@ using UnityEngine;
 
 public class ChopTreeTask : TimedTask
 {
-    public ChopTreeTask(Vector2 target, float duration, System.Action<Colonist> onComplete = null) : base(target, duration, onComplete)
+    public ChopTreeTask(Vector2 target, float duration, System.Action<Colonist> onComplete = null)
+        : base(target, duration, onComplete, JobType.Chop)
     {
     }
 }

--- a/Assets/Scripts/Colonists/Colonist.cs
+++ b/Assets/Scripts/Colonists/Colonist.cs
@@ -152,7 +152,7 @@ public class Colonist : MonoBehaviour
 
         if (currentTask == null)
         {
-            currentTask = taskManager != null ? taskManager.GetNextTask() : null;
+            currentTask = taskManager != null ? taskManager.GetNextTask(this) : null;
 
             if (currentTask != null)
             {

--- a/Assets/Scripts/Colonists/HaulLogTask.cs
+++ b/Assets/Scripts/Colonists/HaulLogTask.cs
@@ -12,7 +12,7 @@ public class HaulLogTask : Task
     public Stage stage = Stage.MoveToLog;
 
     public HaulLogTask(WoodLog log, Vector2Int targetCell)
-        : base(Vector2.zero)
+        : base(Vector2.zero, null, JobType.Haul)
     {
         this.log = log;
         this.targetCell = targetCell;

--- a/Assets/Scripts/Colonists/Task.cs
+++ b/Assets/Scripts/Colonists/Task.cs
@@ -4,11 +4,13 @@ public class Task
 {
     public Vector2 target;
     public System.Action<Colonist> onComplete;
+    public JobType? RequiredJob { get; private set; }
 
-    public Task(Vector2 target, System.Action<Colonist> onComplete = null)
+    public Task(Vector2 target, System.Action<Colonist> onComplete = null, JobType? requiredJob = null)
     {
         this.target = target;
         this.onComplete = onComplete;
+        RequiredJob = requiredJob;
     }
 
     public void Complete(Colonist c)

--- a/Assets/Scripts/Colonists/TaskManager.cs
+++ b/Assets/Scripts/Colonists/TaskManager.cs
@@ -10,10 +10,23 @@ public class TaskManager : MonoBehaviour
         tasks.Enqueue(task);
     }
 
-    public Task GetNextTask()
+    public Task GetNextTask(Colonist colonist)
     {
-        if (tasks.Count > 0)
+        if (colonist != null && tasks.Count > 0)
+        {
+            int count = tasks.Count;
+            for (int i = 0; i < count; i++)
+            {
+                var task = tasks.Dequeue();
+                if (!task.RequiredJob.HasValue || colonist.IsJobAllowed(task.RequiredJob.Value))
+                    return task;
+                tasks.Enqueue(task);
+            }
+        }
+        else if (tasks.Count > 0)
+        {
             return tasks.Dequeue();
+        }
 
         if (StockpileZone.HasAny)
         {
@@ -23,7 +36,8 @@ public class TaskManager : MonoBehaviour
                 if (l != null && !l.Reserved)
                 {
                     Vector2Int target = StockpileZone.GetClosestCell(l.transform.position);
-                    return new HaulLogTask(l, target);
+                    if (colonist == null || colonist.IsJobAllowed(JobType.Haul))
+                        return new HaulLogTask(l, target);
                 }
             }
         }

--- a/Assets/Scripts/Colonists/TimedTask.cs
+++ b/Assets/Scripts/Colonists/TimedTask.cs
@@ -4,7 +4,8 @@ public class TimedTask : Task
 {
     public float duration;
 
-    public TimedTask(Vector2 target, float duration, System.Action<Colonist> onComplete = null) : base(target, onComplete)
+    public TimedTask(Vector2 target, float duration, System.Action<Colonist> onComplete = null, JobType? requiredJob = null)
+        : base(target, onComplete, requiredJob)
     {
         this.duration = duration;
     }


### PR DESCRIPTION
## Summary
- add job requirements to queued tasks and ensure colonists only accept jobs they are assigned to perform
- tag build, chop, and haul tasks with the proper job types so UI toggles take effect
- avoid auto-generating hauling work for colonists who have hauling disabled

## Testing
- not run (Unity project, no automated tests provided)


------
https://chatgpt.com/codex/tasks/task_e_68ca58fe16dc832a8900f27eba087b94