### PR TITLE
Implement colonist manual actions from info card

### DIFF
--- a/Assets/Scripts/UI/ColonistControlUI.cs
+++ b/Assets/Scripts/UI/ColonistControlUI.cs
@@ -48,4 +48,17 @@ public class ColonistControlUI : MonoBehaviour
                 infoCard.Hide();
         }
     }
+
+    public void BeginManualMove(Colonist colonist)
+    {
+        if (colonist == null)
+            return;
+        selected = colonist;
+    }
+
+    public void CancelManualMove(Colonist colonist)
+    {
+        if (colonist == null || selected == colonist)
+            selected = null;
+    }
 }


### PR DESCRIPTION
## Summary
- wire the colonist info card action buttons to real handlers for cancelling work, editing priorities, resting, and manual moves
- add a focus/highlight workflow to the colonist menu so a colonist row is easy to find when editing priorities from the card
- expose manual move controls from ColonistControlUI and provide a fallback click-to-move mode when that UI is absent

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d780b830a0832aa9e8b7340bb86507