### PR TITLE
Release reserved resources when cancelling colonist tasks

### DIFF
--- a/Assets/Scripts/Colonists/BuildWallTask.cs
+++ b/Assets/Scripts/Colonists/BuildWallTask.cs
@@ -20,4 +20,13 @@ public class BuildWallTask : Task
         this.buildTime = buildTime;
         this.woodNeeded = woodNeeded;
     }
+
+    public void ReleaseReservation()
+    {
+        if (targetLog != null)
+        {
+            targetLog.Reserved = false;
+        }
+        targetLog = null;
+    }
 }

--- a/Assets/Scripts/Colonists/Colonist.cs
+++ b/Assets/Scripts/Colonists/Colonist.cs
@@ -83,6 +83,14 @@ public class Colonist : MonoBehaviour
 
     public void SetTask(Task task)
     {
+        if (currentTask == task)
+            return;
+
+        if (currentTask != null)
+        {
+            ReleaseCurrentTaskReservation();
+        }
+
         currentTask = task;
         if (currentTask != null)
         {
@@ -118,9 +126,30 @@ public class Colonist : MonoBehaviour
 
     public void CancelTasks()
     {
+        if (currentTask != null)
+        {
+            ReleaseCurrentTaskReservation();
+        }
+
         currentTask = null;
         path = null;
         activity = "Idle";
+    }
+
+    void ReleaseCurrentTaskReservation()
+    {
+        if (currentTask is BuildWallTask buildTask)
+        {
+            buildTask.ReleaseReservation();
+        }
+        else if (currentTask is HaulLogTask haulTask)
+        {
+            haulTask.ReleaseReservation();
+        }
+        else if (currentTask is RestTask restTask)
+        {
+            restTask.ReleaseReservation();
+        }
     }
 
     void Update()
@@ -434,8 +463,7 @@ public class Colonist : MonoBehaviour
                 fatigue = Mathf.Clamp01(fatigue - Time.deltaTime / task.restTime);
                 if (actionTimer <= 0f)
                 {
-                    if (task.bed != null)
-                        task.bed.Reserved = false;
+                    task.ReleaseReservation();
                     currentTask = null;
                     activity = "Idle";
                 }

--- a/Assets/Scripts/Colonists/HaulLogTask.cs
+++ b/Assets/Scripts/Colonists/HaulLogTask.cs
@@ -19,4 +19,13 @@ public class HaulLogTask : Task
         if (log != null)
             log.Reserved = true;
     }
+
+    public void ReleaseReservation()
+    {
+        if (log != null)
+        {
+            log.Reserved = false;
+        }
+        log = null;
+    }
 }

--- a/Assets/Scripts/Colonists/RestTask.cs
+++ b/Assets/Scripts/Colonists/RestTask.cs
@@ -18,4 +18,13 @@ public class RestTask : Task
         if (bed != null)
             bed.Reserved = true;
     }
+
+    public void ReleaseReservation()
+    {
+        if (bed != null)
+        {
+            bed.Reserved = false;
+        }
+        bed = null;
+    }
 }


### PR DESCRIPTION
## Summary
- add reservation release helpers for build, haul, and rest colonist tasks
- ensure colonists drop reserved objects whenever tasks are cancelled or replaced
- reuse the release helpers when rest tasks complete to reset bed availability

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e530c7d3b4832a82654b85e6cfa7aa